### PR TITLE
Enable forward-headers-strategy for nginx-ssl profile

### DIFF
--- a/src/main/resources/application-nginx-ssl.yaml
+++ b/src/main/resources/application-nginx-ssl.yaml
@@ -1,3 +1,5 @@
+server:
+  forward-headers-strategy: native
 spring:
   docker:
     compose:


### PR DESCRIPTION
This commit fixes a mixed content issue when running the application with the `nginx-ssl` profile. By setting `server.forward-headers-strategy` to `native`, the Spring Boot application can correctly handle the `X-Forwarded-Proto` header from the Nginx reverse proxy. This ensures that all URLs generated by the application, including those for Keycloak redirects, use the `https` scheme.