### PR TITLE
Add request logging to all controllers, fix flashcard review ordering…

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ docker compose -f docker-compose-vocabulary-api.yaml up
 ```
 
 
+## Unit Tests
+
+Run the full test suite:
+```shell
+mvn test
+```
+
+### Skipping slow Keycloak tests
+
+Tests tagged with `keycloak` (e.g. `KeycloakClientServiceTest`) spin up a Testcontainers Keycloak instance and can be slow.
+To skip them, activate the `skip-keycloak` Maven profile:
+
+```shell
+mvn test -P skip-keycloak
+```
+
 ## Developer Notes
 * [Developer Notes](docs/developer-notes.md)
 * [Hetzner Notes](docs/api-hetzner.md)

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,22 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>skip-keycloak</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludedGroups>keycloak</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <!-- your-rents dependencies -->

--- a/src/main/java/org/enricogiurin/vocabulary/api/flashcard/WordLearningRepository.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/flashcard/WordLearningRepository.java
@@ -116,7 +116,9 @@ public class WordLearningRepository {
         .and(WORD.USER_ID.eq(userId))
         .orderBy(
             DSL.when(WORD_LEARNING.ID.isNull(), 0).otherwise(1).asc(),
-            WORD_LEARNING.WRONG_COUNT.desc().nullsLast())
+            WORD_LEARNING.SKIP_COUNT.desc().nullsLast(),
+            WORD_LEARNING.WRONG_COUNT.desc().nullsLast(),
+            WORD_LEARNING.RIGHT_COUNT.asc().nullsLast())
         .limit(limit)
         .fetch(r -> new WordView(
             r.get(WORD.EXTERNAL_ID),

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/admin/KeycloakUserController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/admin/KeycloakUserController.java
@@ -22,6 +22,7 @@ package org.enricogiurin.vocabulary.api.rest.admin;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.enricogiurin.vocabulary.api.service.KeycloakClientService;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.http.ResponseEntity;
@@ -32,12 +33,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("${application.api.admin-path}/keycloak/user")
 @RequiredArgsConstructor
+@Slf4j
 public class KeycloakUserController {
 
   private final KeycloakClientService keycloakAdminService;
 
   @GetMapping()
   public ResponseEntity<List<UserRepresentation>> list() {
+    log.info("GET /keycloak/user");
     List<UserRepresentation> list = keycloakAdminService.userList();
     return ResponseEntity.ok(list);
   }

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/me/FlashcardController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/me/FlashcardController.java
@@ -24,6 +24,7 @@ import com.yourrents.services.common.util.exception.DataNotFoundException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.enricogiurin.vocabulary.api.flashcard.WordLearning;
 import org.enricogiurin.vocabulary.api.flashcard.WordLearningRepository;
 import org.enricogiurin.vocabulary.api.flashcard.WordReviewResult;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("${application.api.user-path}/flashcards")
 @RequiredArgsConstructor
+@Slf4j
 public class FlashcardController {
 
   private final WordLearningRepository wordLearningRepository;
@@ -51,6 +53,8 @@ public class FlashcardController {
       @RequestParam UUID language,
       @RequestParam UUID languageTo,
       @RequestParam(defaultValue = "10") int limit) {
+    log.info("GET /flashcards/words - subject: {}, language: {}, languageTo: {}, limit: {}",
+        currentUser.getSubject(), language, languageTo, limit);
     List<WordView> words = wordLearningRepository.findWordsForReview(
         language, languageTo, currentUser.getUserId(), limit);
     return ResponseEntity.ok(words);
@@ -58,6 +62,7 @@ public class FlashcardController {
 
   @GetMapping("/words/{wordUuid}")
   ResponseEntity<WordLearning> findByWordUuid(@PathVariable UUID wordUuid) {
+    log.info("GET /flashcards/words/{} - subject: {}", wordUuid, currentUser.getSubject());
     WordLearning result = wordLearningRepository.findByWordExternalId(wordUuid)
         .orElseThrow(() -> new DataNotFoundException(
             "No learning record found for word: " + wordUuid));
@@ -66,6 +71,8 @@ public class FlashcardController {
 
   @PostMapping("/review")
   ResponseEntity<WordLearning> review(@RequestBody WordReviewResult wordReviewResult) {
+    log.info("POST /flashcards/review - subject: {}, wordUuid: {}, result: {}",
+        currentUser.getSubject(), wordReviewResult.wordUuid(), wordReviewResult.wordReviewResultType());
     WordLearning result = wordLearningRepository.review(wordReviewResult);
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/me/LanguageTranslateController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/me/LanguageTranslateController.java
@@ -51,6 +51,7 @@ public class LanguageTranslateController {
 
   @GetMapping("quota-reached")
   public ResponseEntity<Boolean> isTranslationQuotaReached() {
+    log.info("GET /translate/quota-reached");
     return ResponseEntity.ok(translateService.isQuotaReached());
   }
 

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/me/UserLanguagesController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/me/UserLanguagesController.java
@@ -49,6 +49,7 @@ public class UserLanguagesController {
 
   @GetMapping
   public ResponseEntity<UserLanguages> getUserLanguages() {
+    log.info("GET /user-languages - subject: {}", currentUser.getSubject());
     return userService.userLanguages(currentUser.getUserId())
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.ok(UserLanguages.empty()));
@@ -56,6 +57,7 @@ public class UserLanguagesController {
 
   @PutMapping
   public ResponseEntity<UserLanguages> storeUserLanguages(@RequestBody UserLanguages userLanguages) {
+    log.info("PUT /user-languages - subject: {}", currentUser.getSubject());
     UserLanguages result = userService.saveUserLanguages(userLanguages, currentUser.getUserId());
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/me/WordController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/me/WordController.java
@@ -25,6 +25,7 @@ import com.yourrents.services.common.searchable.Searchable;
 import com.yourrents.services.common.util.exception.DataNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.enricogiurin.vocabulary.api.model.Word;
 import org.enricogiurin.vocabulary.api.repository.WordRepository;
 import org.enricogiurin.vocabulary.api.security.CurrentUser;
@@ -50,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("${application.api.user-path}/words")
 @RequiredArgsConstructor
+@Slf4j
 public class WordController {
 
   private final WordRepository wordRepository;
@@ -59,13 +61,14 @@ public class WordController {
   ResponseEntity<Page<Word>> find(
       @ParameterObject Searchable filter,
       @ParameterObject @SortDefault(sort = WordRepository.UPDATED_AT, direction = Direction.DESC) Pageable pagination) {
-
+    log.info("GET /words - subject: {}, filter: {}, pagination: {}", currentUser.getSubject(), filter, pagination);
     Page<Word> page = wordRepository.find(filter, pagination, currentUser.getUserId());
     return ResponseEntity.ok(page);
   }
 
   @GetMapping("/{uuid}")
   ResponseEntity<Word> findByUuid(@PathVariable UUID uuid) {
+    log.info("GET /words/{} - subject: {}", uuid, currentUser.getSubject());
     Word result = wordRepository.findByExternalId(uuid, currentUser.getUserId())
         .orElseThrow(
             () -> new DataNotFoundException("can't find Word having uuid: " + uuid));
@@ -74,12 +77,14 @@ public class WordController {
 
   @PostMapping
   ResponseEntity<Word> add( @Validated(ValidationGroups.Post.class) @RequestBody Word word) {
+    log.info("POST /words - subject: {}", currentUser.getSubject());
     Word savedProperty = wordRepository.create(word, currentUser.getUserId());
     return new ResponseEntity<>(savedProperty, HttpStatus.CREATED);
   }
 
   @PatchMapping("/{uuid}")
   ResponseEntity<Word> update(@PathVariable UUID uuid,   @Validated(ValidationGroups.Patch.class) @RequestBody Word wordToUpdate) {
+    log.info("PATCH /words/{} - subject: {}", uuid, currentUser.getSubject());
     Word updatedProperty = wordRepository.update(uuid, wordToUpdate, currentUser.getUserId());
     return ResponseEntity.ok(updatedProperty);
   }
@@ -87,6 +92,7 @@ public class WordController {
   @DeleteMapping("/{uuid}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   void delete(@PathVariable UUID uuid) {
+    log.info("DELETE /words/{} - subject: {}", uuid, currentUser.getSubject());
     wordRepository.delete(uuid, currentUser.getUserId());
   }
 

--- a/src/main/java/org/enricogiurin/vocabulary/api/rest/pub/CheckMyRolesController.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/rest/pub/CheckMyRolesController.java
@@ -39,6 +39,7 @@ class CheckMyRolesController {
 
   @GetMapping
   ResponseEntity<List<String>> roles(Authentication authentication) {
+    log.info("GET /roles - principal: {}", authentication != null ? authentication.getName() : "anonymous");
     if(authentication==null){
       log.warn("user not authenticated");
       return ResponseEntity.ok(List.of());

--- a/src/test/java/org/enricogiurin/vocabulary/api/flashcard/WordLearningRepositoryTest.java
+++ b/src/test/java/org/enricogiurin/vocabulary/api/flashcard/WordLearningRepositoryTest.java
@@ -127,17 +127,18 @@ class WordLearningRepositoryTest {
   }
 
   @Test
-  void findWordsForReview_returnsUnreviewedFirstThenWorstWrongCount() {
+  void findWordsForReview_ordersUnreviewedFirstThenSkipDescWrongDescRightAsc() {
     UUID enUuid = languageRepository.findByName("English").orElseThrow().uuid();
     UUID itUuid = languageRepository.findByName("Italian").orElseThrow().uuid();
     List<WordView> result = wordLearningRepository.findWordsForReview(enUuid, itUuid, USER_ENRICO_ID, 10);
     assertThat(result, hasSize(4));
-    // first two are unreviewed (cat, tomcat) in any order
+    // 1) unreviewed words come first (cat, tomcat — no WORD_LEARNING record), in any order
     assertThat(result.subList(0, 2).stream().map(WordView::sentence).toList(),
         containsInAnyOrder("cat", "tomcat"));
-    // last two are reviewed ordered by wrongCount desc
-    assertThat(result.subList(2, 4).stream().map(WordView::sentence).toList(),
-        contains("my house", "Hello"));
+    // 2) Hello: skip=1 → highest skip count among reviewed words
+    assertThat(result.get(2).sentence(), equalTo("Hello"));
+    // 3) my house: skip=0, wrong=3 → no skip, falls back to wrong count desc
+    assertThat(result.get(3).sentence(), equalTo("my house"));
   }
 
   @Test

--- a/src/test/java/org/enricogiurin/vocabulary/api/rest/me/FlashcardControllerTest.java
+++ b/src/test/java/org/enricogiurin/vocabulary/api/rest/me/FlashcardControllerTest.java
@@ -87,9 +87,9 @@ class FlashcardControllerTest {
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$", hasSize(4)))
-        // last two are reviewed, ordered by wrongCount DESC
-        .andExpect(jsonPath("$[2].sentence", is("my house")))
-        .andExpect(jsonPath("$[3].sentence", is("Hello")));
+        // last two are reviewed: Hello (skip=1) before my house (skip=0, wrong=3)
+        .andExpect(jsonPath("$[2].sentence", is("Hello")))
+        .andExpect(jsonPath("$[3].sentence", is("my house")));
   }
 
   @Test

--- a/src/test/java/org/enricogiurin/vocabulary/api/service/KeycloakClientServiceTest.java
+++ b/src/test/java/org/enricogiurin/vocabulary/api/service/KeycloakClientServiceTest.java
@@ -29,6 +29,7 @@ import org.enricogiurin.vocabulary.api.VocabularyTestConfiguration;
 import org.enricogiurin.vocabulary.api.exception.DataConflictException;
 import org.enricogiurin.vocabulary.api.model.KeycloakUser;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -43,6 +44,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Import({VocabularyTestConfiguration.class})
 @Transactional
 @Testcontainers
+@Tag("keycloak")
 class KeycloakClientServiceTest {
 
   private static final String USER_EMAIL = "john.doe@example.com";


### PR DESCRIPTION
…, and skip-keycloak profile

- Fix findWordsForReview ordering: unreviewed first, then skip desc, wrong desc, right asc
- Add INFO log at the start of every controller endpoint (subject, verb, params)
- Add @Tag("keycloak") to KeycloakClientServiceTest and skip-keycloak Maven profile
- Update tests to reflect new ordering and add Unit Tests section to README