### PR TITLE
Fix ClassCastException when principal is not a Jwt in UserProvisionin…

### DIFF
--- a/docker-hetzner/config/logback-hetzner.xml
+++ b/docker-hetzner/config/logback-hetzner.xml
@@ -10,7 +10,7 @@
     </rollingPolicy>
 
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{username}] %-5level [%thread] %-5level %logger{36}.%method:%line - %msg%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%X{username}]  [%thread] %logger{36}.%method:%line - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/src/main/java/org/enricogiurin/vocabulary/api/security/UserProvisioningFilter.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/security/UserProvisioningFilter.java
@@ -25,6 +25,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.enricogiurin.vocabulary.api.service.UserService;
 import org.slf4j.MDC;
 import org.enricogiurin.vocabulary.api.service.UserService.UserCreationAttributes;
@@ -32,8 +33,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @Component
-
 public class UserProvisioningFilter extends OncePerRequestFilter {
 
   private final PrincipalAccessor principalAccessor;
@@ -68,6 +69,11 @@ public class UserProvisioningFilter extends OncePerRequestFilter {
       HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
+    if (!principalAccessor.isValid()) {
+      log.info("Principal is not a JWT, skipping user provisioning for request: {}", request.getRequestURI());
+      filterChain.doFilter(request, response);
+      return;
+    }
     String subject = principalAccessor.getSubject();
     if (subject != null) {
       MDC.put("username", principalAccessor.getUsername());

--- a/src/test/java/org/enricogiurin/vocabulary/api/security/UserProvisioningFilterTest.java
+++ b/src/test/java/org/enricogiurin/vocabulary/api/security/UserProvisioningFilterTest.java
@@ -1,0 +1,91 @@
+package org.enricogiurin.vocabulary.api.security;
+
+/*-
+ * #%L
+ * Vocabulary API
+ * %%
+ * Copyright (C) 2024 - 2026 Vocabulary Team
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.enricogiurin.vocabulary.api.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@TestPropertySource(locations = "classpath:application.yml")
+class UserProvisioningFilterTest {
+
+  @Value("${application.api.public-path}")
+  String publicPath;
+
+  @Value("${application.api.user-path}")
+  String userPath;
+
+  @Mock PrincipalAccessor principalAccessor;
+  @Mock UserService userService;
+  @Mock CurrentUser currentUser;
+  @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
+  @Mock FilterChain filterChain;
+
+  UserProvisioningFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    filter = new UserProvisioningFilter(principalAccessor, userService, currentUser, publicPath);
+  }
+
+  @Test
+  void doFilter_skipsProvisioningWhenPrincipalIsNotJwt() throws Exception {
+    when(request.getRequestURI()).thenReturn(userPath + "/users");
+    when(principalAccessor.isValid()).thenReturn(false);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(principalAccessor, never()).getSubject();
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void doFilter_provisionsUserWhenPrincipalIsJwt() throws Exception {
+    when(request.getRequestURI()).thenReturn(userPath + "/users");
+    when(principalAccessor.isValid()).thenReturn(true);
+    when(principalAccessor.getSubject()).thenReturn("some-keycloak-id");
+    when(principalAccessor.getUsername()).thenReturn("john");
+    when(userService.findOrSaveUserIdByKeycloakId(any(), any())).thenReturn(42);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(userService).findOrSaveUserIdByKeycloakId(any(), any());
+    verify(currentUser).setUserId(42);
+    verify(currentUser).setSubject("some-keycloak-id");
+    verify(filterChain).doFilter(request, response);
+  }
+}


### PR DESCRIPTION
…gFilter

Guard with isValid() before accessing JWT claims to prevent String-to-Jwt cast error. Add log info when provisioning is skipped and unit tests.