### PR TITLE
Improve exception logging in APIExceptionHandler

### DIFF
--- a/src/main/java/org/enricogiurin/vocabulary/api/exception/APIExceptionHandler.java
+++ b/src/main/java/org/enricogiurin/vocabulary/api/exception/APIExceptionHandler.java
@@ -45,7 +45,7 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(DataNotFoundException.class)
   public ResponseEntity<Object> dataNotFound(DataNotFoundException e, NativeWebRequest request) {
-    log.error(e.getMessage(), e);
+    logException(e);
     return super.handleExceptionInternal(e,
         buildErrorResponse(e.getMessage(), e, request, HttpStatus.NOT_FOUND.value()),
         new HttpHeaders(), HttpStatus.NOT_FOUND, request);
@@ -53,7 +53,7 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(DataConflictException.class)
   public ResponseEntity<Object> dataConflict(DataConflictException e, NativeWebRequest request) {
-    log.error(e.getMessage(), e);
+    logException(e);
     return super.handleExceptionInternal(e,
         buildErrorResponse(e.getMessage(), e, request, HttpStatus.CONFLICT.value()),
         new HttpHeaders(), HttpStatus.CONFLICT, request);
@@ -61,7 +61,7 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(DataExecutionException.class)
   public ResponseEntity<Object> dataExecution(DataExecutionException e, NativeWebRequest request) {
-    log.error(e.getMessage(), e);
+    logException(e);
     return super.handleExceptionInternal(e,
         buildErrorResponse(e.getMessage(), e, request, HttpStatus.INTERNAL_SERVER_ERROR.value()),
         new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
@@ -69,7 +69,7 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(KeycloakException.class)
   public ResponseEntity<Object> keycloak(KeycloakException e, NativeWebRequest request) {
-    log.error(e.getMessage(), e);
+    logException(e);
     return super.handleExceptionInternal(e,
         buildErrorResponse(e.getMessage(), e, request, HttpStatus.INTERNAL_SERVER_ERROR.value()),
         new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
@@ -78,7 +78,7 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(QuotaExceededException.class)
   public ResponseEntity<Object> handleQuotaExceeded(QuotaExceededException e,
       NativeWebRequest request) {
-    log.error(e.getMessage(), e);
+    logException(e);
     return super.handleExceptionInternal(e,
         buildErrorResponse(e.getMessage(), e, request, HttpStatus.TOO_MANY_REQUESTS.value()),
         new HttpHeaders(), HttpStatus.TOO_MANY_REQUESTS, request);
@@ -110,6 +110,19 @@ class APIExceptionHandler extends ResponseEntityExceptionHandler {
   /*
    **** helpers ****
    */
+  void logException(Exception e) {
+    StackTraceElement[] stackTrace = e.getStackTrace();
+    if (stackTrace.length > 0) {
+      StackTraceElement origin = stackTrace[0];
+      log.warn("{} at {}.{}:{} - {}",
+          e.getClass().getSimpleName(),
+          origin.getClassName(), origin.getMethodName(), origin.getLineNumber(),
+          e.getMessage());
+    } else {
+      log.warn("{} - {}", e.getClass().getSimpleName(), e.getMessage());
+    }
+  }
+
   private ApiError buildErrorResponse(String message, Exception e, NativeWebRequest request,
       int status) {
     return new ApiError(message, e.getMessage(), status,

--- a/src/test/java/org/enricogiurin/vocabulary/api/exception/APIExceptionHandlerTest.java
+++ b/src/test/java/org/enricogiurin/vocabulary/api/exception/APIExceptionHandlerTest.java
@@ -1,0 +1,81 @@
+package org.enricogiurin.vocabulary.api.exception;
+
+/*-
+ * #%L
+ * Vocabulary API
+ * %%
+ * Copyright (C) 2024 - 2026 Vocabulary Team
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class APIExceptionHandlerTest {
+
+  APIExceptionHandler handler;
+  ListAppender<ILoggingEvent> listAppender;
+
+  @BeforeEach
+  void setUp() {
+    handler = new APIExceptionHandler();
+    listAppender = new ListAppender<>();
+    listAppender.start();
+    ((Logger) LoggerFactory.getLogger(APIExceptionHandler.class)).addAppender(listAppender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ((Logger) LoggerFactory.getLogger(APIExceptionHandler.class)).detachAppender(listAppender);
+  }
+
+  @Test
+  void logException_logsOriginWhenStackTraceIsPresent() {
+    DataNotFoundException e = new DataNotFoundException("resource not found");
+    StackTraceElement origin = e.getStackTrace()[0];
+
+    handler.logException(e);
+
+    assertThat(listAppender.list).hasSize(1);
+    assertThat(origin.getClassName()).isEqualTo(APIExceptionHandlerTest.class.getName());
+    assertThat(listAppender.list.get(0).getFormattedMessage())
+        .contains("DataNotFoundException")
+        .contains(origin.getClassName())
+        .contains(origin.getMethodName())
+        .contains(String.valueOf(origin.getLineNumber()))
+        .contains("resource not found");
+  }
+
+  @Test
+  void logException_doesNotThrowWhenStackTraceIsEmpty() {
+    DataNotFoundException e = new DataNotFoundException("resource not found");
+    e.setStackTrace(new StackTraceElement[0]);
+
+    handler.logException(e);
+
+    assertThat(listAppender.list).hasSize(1);
+    assertThat(listAppender.list.get(0).getFormattedMessage())
+        .contains("DataNotFoundException")
+        .contains("resource not found")
+        .doesNotContain(APIExceptionHandlerTest.class.getName());
+  }
+}


### PR DESCRIPTION
Replace full stacktrace logging with a targeted log showing class, method, and line number of the origin. Extract shared logException() helper and add unit tests verifying the log output.